### PR TITLE
Reimplement w.r.t _modify_leafs method

### DIFF
--- a/aiger/aig.py
+++ b/aiger/aig.py
@@ -276,7 +276,6 @@ class AIG(NamedTuple):
         with open(path, 'w') as f:
             f.write(repr(self))
 
-
     def _modify_leafs(self, func):
         node_map = frozenset(
             (name, _modify_leafs(cone, func)) for name, cone in self.node_map
@@ -530,8 +529,8 @@ def seq_compose(aig1, aig2, check_precondition=True):
     assert not aig1.latches & aig2.latches
 
     passthrough = {(k, v) for k, v in aig1.node_map if k not in interface}
-
     lookup = dict(aig1.node_map)
+
     def sub(node):
         if isinstance(node, Input):
             return lookup.get(node.name, node)

--- a/aiger/aig.py
+++ b/aiger/aig.py
@@ -83,9 +83,15 @@ class AIG(NamedTuple):
         kind, relabels = others
         assert kind in {'i', 'o', 'l'}
 
+        basis = {
+            'i': self.inputs, 'o': self.outputs, 'l': self.latches
+        }.get(kind)
+        relabels = fn.project(relabels, basis)
+
         if kind == 'o':
             relabels = {k: [v] for k, v in relabels.items()}
             return self >> cmn.tee(relabels)
+
         relabels = {v: [k] for k, v in relabels.items()}
         input_kinds = (Input,) if kind == 'i' else (LatchIn,)
         return seq_compose(cmn.tee(relabels), self, input_kinds=input_kinds)

--- a/aiger/aig.py
+++ b/aiger/aig.py
@@ -294,15 +294,12 @@ class AIG(NamedTuple):
 
             return func(node)
 
-
-        node_map = frozenset(
-            (name, _mod(cone)) for name, cone in self.node_map
+        node_map = ((name, _mod(cone)) for name, cone in self.node_map)
+        latch_map = ((name, _mod(cone)) for name, cone in self.latch_map)
+        return self._replace(
+            node_map=frozenset(node_map),
+            latch_map=frozenset(latch_map)
         )
-
-        latch_map = frozenset(
-            (name, _mod(cone)) for name, cone in self.latch_map
-        )
-        return self._replace(node_map=node_map, latch_map=latch_map)
 
 
 def _to_idx(lit):

--- a/aiger/aig.py
+++ b/aiger/aig.py
@@ -116,7 +116,7 @@ class AIG(NamedTuple):
     def _eval_order(self):
         return list(toposort(_dependency_graph(self.cones | self.latch_cones)))
 
-    def __call__(self, inputs, latches=None, *, as_aig=False):
+    def __call__(self, inputs, latches=None):
         if latches is None:
             latches = dict()
         latchins = fn.merge(dict(self.latch2init), latches)
@@ -128,9 +128,6 @@ class AIG(NamedTuple):
             return Inverter(ConstFalse()) if store[node.name] else ConstFalse()
 
         circ = self._modify_leafs(sub)
-        if as_aig or circ.inputs:
-            return circ
-
         outputs = {n: _is_const_true(node) for n, node in circ.node_map}
         latch_outputs = {n: _is_const_true(node) for n, node in circ.latch_map}
         return outputs, latch_outputs

--- a/aiger/hypothesis.py
+++ b/aiger/hypothesis.py
@@ -1,6 +1,5 @@
 import hypothesis.strategies as st
 from hypothesis_cfg import ContextFreeGrammarStrategy
-from lenses import bind
 from parsimonious import Grammar, NodeVisitor
 
 from aiger import common, expr
@@ -70,7 +69,7 @@ GRAMMAR = {
 
 def make_circuit(term):
     circ_str = ''.join(term)
-    return bind(parse(circ_str)).comments.set((circ_str, ))
+    return parse(circ_str)._replace(comments=(circ_str, ))
 
 
 Circuits = st.builds(make_circuit,

--- a/aiger/test_common.py
+++ b/aiger/test_common.py
@@ -152,7 +152,7 @@ def test_relabel(aag1):
     new_outputs = {k: f'{k}#2' for k in aag1.outputs}
     assert set(aag1['o', new_outputs].outputs) == set(new_outputs.values())
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(AssertionError):
         aag1['z', {}]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ click==6.7
 codecov==2.0.15
 funcy==1.10.3
 hypothesis==3.66.30
-lenses==0.4.0
 parsimonious==0.8.1
 pytest==3.2.3 # pyup: ignore
 pytest-cov==2.5.1 # pyup: ignore

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'bidict',
         'click',
         'funcy',
-        'lenses',
         'parsimonious',
         'toposort',
     ],


### PR DESCRIPTION
- Re-implement relabeling in terms of `_modify_leafs`
- Remove `lenses` library dependence 
- Re-implement `__call__` in terms of `_modify_leafs`
- Re-implement `feedback` in terms of `_modify_leafs`
- Make `fn.memoize` go out of scope after call. Should address #65 