### PR TITLE
Eval order

### DIFF
--- a/aiger/aig.py
+++ b/aiger/aig.py
@@ -120,8 +120,17 @@ class AIG:
 
         return circ._modify_leafs(sub)
 
-    def __iter_gates__(self, *, concat=False):
-        return cmn.eval_order(self, concat=concat)
+    def __iter_nodes__(self):
+        """Returns an iterator over iterators of nodes in an AIG.
+
+        If completely flattened this iterator would give topological
+        a order on the nodes, starting on the inputs.
+
+        The reason for the iterator over iterators is to mark
+        dependencies. Namely, to compute the value of any node
+        requires just the value of the nodes in the previous iterator.
+        """
+        yield cmn.eval_order(self, concat=True)
 
     def evolve(self, **kwargs):
         return attr.evolve(self, **kwargs)
@@ -176,7 +185,7 @@ class AIG:
         latchins = fn.project(latchins, self.latches)
 
         tbl = {}
-        for frontier in self.__iter_gates__():
+        for frontier in self.__iter_nodes__():
             for gate in frontier:
                 if isinstance(gate, Inverter):
                     tbl[gate] = not tbl[gate.input]

--- a/aiger/common.py
+++ b/aiger/common.py
@@ -177,5 +177,6 @@ def _dependency_graph(nodes):
     return deps
 
 
-def eval_order(circ):
-    return fn.lcat(toposort(_dependency_graph(circ.cones | circ.latch_cones)))
+def eval_order(circ, *, concat=True):
+    order = toposort(_dependency_graph(circ.cones | circ.latch_cones))
+    return fn.lcat(order) if concat else order

--- a/aiger/common.py
+++ b/aiger/common.py
@@ -177,6 +177,7 @@ def _dependency_graph(nodes):
     return deps
 
 
-def eval_order(circ, *, concat=True):
+def eval_order(circ, *, concat: bool = True):
+    """Return topologically sorted nodes in AIG."""
     order = toposort(_dependency_graph(circ.cones | circ.latch_cones))
     return fn.lcat(order) if concat else order


### PR DESCRIPTION
Implemented `__call__` in terms of `AIG.__iter_nodes__`.

In addition to a moderate speed improvement, this marks in important step towards lazy evaluation of `AIG`s by simply chaining `AIG.__iter_nodes__`.

While not used yet, the semantics of `__iter_nodes__` also allows us to eventually become more space efficient.

Finally, I added support for interpreting the `AIG` over another boolean algebra. I think this will really simplify the current implementations of `aiger-bdd` and `aiger-cnf`.

@MarkusRabe Any thoughts?