### PR TITLE
fixed outputs as an unsorted list

### DIFF
--- a/aiger/parser.py
+++ b/aiger/parser.py
@@ -60,7 +60,7 @@ class SymbolTable:
 class State:
     header: Optional[Header] = None
     inputs: SortedSet = attr.ib(factory=SortedSet)
-    outputs: SortedList = attr.ib(factory=SortedList)
+    outputs: list = attr.ib(factory=list)
     latches: SortedSet = attr.ib(factory=SortedSet)
     symbols: SymbolTable = attr.ib(factory=SymbolTable)
     comments: Optional[List[str]] = None
@@ -131,7 +131,7 @@ def parse_output(state, line) -> bool:
     if match is None or state.remaining_outputs <= 0:
         return False
     lit = int(line)
-    state.outputs.add(lit)
+    state.outputs.append(lit)
     if lit & 1:
         state.nodes[lit] = {lit ^ 1}
     return True


### PR DESCRIPTION
This is a small fix to a bug in the way outputs are handled. In fact, the node_map does not assign the right function with the right output. Consider the following circuit which maps input a to oa, and b to ob.

```
aag 2 2 0 2 0  
2  
4  
4  
2  
i0 a
i1 b
o0 ob
o1 oa
c
```
The expected node_map should look like the following:

`pmap({'oa': Input(name='a'), 'ob': Input(name='b')})`

But currently we get:

`pmap({'ob': Input(name='a'), 'oa': Input(name='b')})`

In the parser, the outputs field of State is a SortedList. However this list contains the gates that correspond to the outputs in the order they are defined. So this must not be sorted.